### PR TITLE
Combine normals tiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # CityDataToBinaryModel
 
+## TileBakeTool
+
+The TileBakeTool is and executable that converts CityJSON files from a target folder into combined binary mesh tiles, either by adding the City Objects to a tile using a OVERLAP method, or TILED.
+
+OVERLAP places a CityObject in a mesh tile if its centroid is within the tile bounds.
+TILED cuts CityObjects using the bounds and places the parts into their tiles.
+
+The TileBakeTool can selectively reduce polycount of specific CityObjects, and/or combine double verts, reducing filesize.
+
 ## Using the Tile Bake Tool
 
 Download the latest release from the [releases page](https://github.com/Amsterdam/CityDataToBinaryModel/releases) and extract with .zip file with all its contents to a folder.<br>
@@ -16,3 +25,12 @@ Use `TileBakeTool.exe --config PathToYourConfigFile.json` to start the tool usin
 
 [Binary tile byte order](docs/BinaryFileContents.md)
 
+## GLTF Wrapper
+
+Gltf files are created next to the binary tiles as a wrapper for the binary data.
+This way the binary tiles can be used standalone, or used/imported as Gltf files with external binary mesh data.
+The Gltf files also allow you to preview the 3D output using standard 3D viewers like the one Windows 10+ offers.
+
+## Brotli compression
+
+The TileBakeTool can optionaly create compressed versions of the binary tiles using Brotli compression, reducing download times for streaming in the data in  web applications.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## TileBakeTool
 
-The TileBakeTool is and executable that converts RD coordinate based CityJSON files from a target folder into combined binary mesh tiles. City Objects are added to tiles using an OVERLAP or TILED method.
+The TileBakeTool is an executable that converts RD coordinate based CityJSON files from a target folder into combined binary mesh tiles. City Objects are added to tiles using an OVERLAP or TILED method.
 
 OVERLAP places a CityObject in a mesh tile if its centroid is within the tile bounds.
 TILED cuts CityObjects using the bounds and places the parts into their tiles.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## TileBakeTool
 
-The TileBakeTool is and executable that converts CityJSON files from a target folder into combined binary mesh tiles, either by adding the City Objects to a tile using a OVERLAP method, or TILED.
+The TileBakeTool is and executable that converts RD coordinate based CityJSON files from a target folder into combined binary mesh tiles. City Objects are added to tiles using an OVERLAP or TILED method.
 
 OVERLAP places a CityObject in a mesh tile if its centroid is within the tile bounds.
 TILED cuts CityObjects using the bounds and places the parts into their tiles.
@@ -29,7 +29,7 @@ Use `TileBakeTool.exe --config PathToYourConfigFile.json` to start the tool usin
 
 Gltf files are created next to the binary tiles as a wrapper for the binary data.
 This way the binary tiles can be used standalone, or used/imported as Gltf files with external binary mesh data.
-The Gltf files also allow you to preview the 3D output using standard 3D viewers like the one Windows 10+ offers.
+The Gltf files also allow you to load/preview the 3D output using 3D viewers/tools like the standard Windows 3D Viewer.
 
 ## Brotli compression
 

--- a/TileBakeLibrary/CityJSONToTileConverter.cs
+++ b/TileBakeLibrary/CityJSONToTileConverter.cs
@@ -328,7 +328,7 @@ namespace TileBakeLibrary
 			{
 				if (tile.SubObjects.Count == 0)
 				{
-					//Console.WriteLine($"Skipping {tile.filePath} containing {tile.SubObjects.Count} SubObjects");
+					Console.WriteLine($"Skipping {tile.filePath} containing {tile.SubObjects.Count} SubObjects");
 				}
 				else
 				{
@@ -507,6 +507,7 @@ namespace TileBakeLibrary
 				{
 					submeshindex = cityObjectFilters[i].defaultSubmeshIndex;
 					subObject.maxVerticesPerSquareMeter = cityObjectFilters[i].maxVerticesPerSquareMeter;
+					subObject.skipTrianglesBelowArea = cityObjectFilters[i].skipTrianglesBelowArea;
 					for (int j = 0; j < cityObjectFilters[i].attributeFilters.Length; j++)
 					{
 						string attributename = cityObjectFilters[i].attributeFilters[j].attributeName;

--- a/TileBakeLibrary/Config/ConfigFile.cs
+++ b/TileBakeLibrary/Config/ConfigFile.cs
@@ -45,6 +45,7 @@ public class CityObjectFilter
 	public int defaultSubmeshIndex { get; set; }
 	public AttributeFilter[] attributeFilters { get; set; }
 	public float maxVerticesPerSquareMeter { get; set; }
+	public float skipTrianglesBelowArea { get; set; }
 }
 
 public class AttributeFilter

--- a/TileBakeLibrary/SubObject.cs
+++ b/TileBakeLibrary/SubObject.cs
@@ -104,7 +104,7 @@ namespace TileBakeLibrary
 
 			if(skipTrianglesBelowArea > 0)
             {
-				var removedTriangles = MeshEditor.RemoveSmallComponents(mesh, skipTrianglesBelowArea, skipTrianglesBelowArea);
+				var removedTriangles = MeshEditor.RemoveSmallComponents(mesh, double.MinValue, skipTrianglesBelowArea);
 			}
 
 			MeshNormals.QuickCompute(mesh);

--- a/TileBakeLibrary/SubObject.cs
+++ b/TileBakeLibrary/SubObject.cs
@@ -37,6 +37,7 @@ namespace TileBakeLibrary
 
 		private DMesh3 mesh;
 		public float maxVerticesPerSquareMeter;
+		public float skipTrianglesBelowArea;
 
 		public void MergeSimilarVertices()
 		{
@@ -91,7 +92,6 @@ namespace TileBakeLibrary
 		private void CreateMesh()
         {
 			mesh = new DMesh3(false, false, false, false);
-			
 			for (int i = 0; i < vertices.Count; i++)
 			{
 				mesh.AppendVertex(new Vector3d(vertices[i].X, vertices[i].Y, vertices[i].Z));
@@ -101,6 +101,12 @@ namespace TileBakeLibrary
 			{
 				mesh.AppendTriangle(triangleIndices[i], triangleIndices[i + 1], triangleIndices[i + 2]);
 			}
+
+			if(skipTrianglesBelowArea > 0)
+            {
+				var removedTriangles = MeshEditor.RemoveSmallComponents(mesh, skipTrianglesBelowArea, skipTrianglesBelowArea);
+			}
+
 			MeshNormals.QuickCompute(mesh);
 		}
 

--- a/TileBakeTool/TileBakeTool.sln
+++ b/TileBakeTool/TileBakeTool.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TileBakeTool", "TileBakeTool.csproj", "{0BAF596B-2C1D-48D5-A699-19ED690AAC4A}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
- added new attribute filter property named 'skipTrianglesBelowArea' allowing users to exlude triangles below a specified surface area